### PR TITLE
php8.3 mcrypt

### DIFF
--- a/php-8.3-cli-t/Dockerfile
+++ b/php-8.3-cli-t/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         php8.3-memcache \
         php8.3-imap \
         php8.3-mailparse \
+        php8.3-mcrypt \
         php-pear \
         librabbitmq-dev \
         libmcrypt-dev \

--- a/php-8.3-fpm-t-dev/Dockerfile
+++ b/php-8.3-fpm-t-dev/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     php8.3-memcache \
     php8.3-imap \
     php8.3-mailparse \
+    php8.3-mcrypt \
     php-pear \
     librabbitmq-dev \
     libmcrypt-dev

--- a/php-8.3-fpm-t/Dockerfile
+++ b/php-8.3-fpm-t/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
         php8.3-redis \
         php8.3-gd \
         php8.3-memcache \
+        php8.3-mcrypt \
         php-pear \
         librabbitmq-dev \
         libmcrypt-dev \


### PR DESCRIPTION
Adding in the Mcrypt PECL module for 8.3 so we can carry on using it.