### PR TITLE
Add php8.4-pcov to Dockerfile dependencies

### DIFF
--- a/php-8.4-cli-h-dev/Dockerfile
+++ b/php-8.4-cli-h-dev/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         php8.4-gd \
         php8.4-ldap \
         php8.4-amqp \
+        php8.4-pcov \
         mysql-client \
         supervisor \
         ansible \


### PR DESCRIPTION
Install the `php8.4-pcov` package so we don't need to install in consuming repos